### PR TITLE
연관관계 매핑 관련 실습 코드 반영 (#SECTION-05 ~ 08)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.DS_Store
 HELP.md
 .gradle
 build/

--- a/build.gradle
+++ b/build.gradle
@@ -23,8 +23,8 @@ repositories {
 
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+	implementation 'com.h2database:h2'
 	compileOnly 'org.projectlombok:lombok'
-	runtimeOnly 'com.h2database:h2'
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 }

--- a/src/main/java/practice/jpa1/domain/Album.java
+++ b/src/main/java/practice/jpa1/domain/Album.java
@@ -1,0 +1,12 @@
+package practice.jpa1.domain;
+
+import javax.persistence.Entity;
+
+@Entity
+public class Album extends Item {
+
+    private String artist;
+
+    private String etc;
+
+}

--- a/src/main/java/practice/jpa1/domain/BaseEntity.java
+++ b/src/main/java/practice/jpa1/domain/BaseEntity.java
@@ -1,0 +1,21 @@
+package practice.jpa1.domain;
+
+import java.time.LocalDateTime;
+import javax.persistence.MappedSuperclass;
+import lombok.Getter;
+import lombok.Setter;
+
+@Setter
+@Getter
+@MappedSuperclass
+public abstract class BaseEntity {
+
+    private String createdBy;
+
+    private LocalDateTime createdDateTime;
+
+    private String lastModifiedBy;
+
+    private LocalDateTime lastModifiedDateTime;
+
+}

--- a/src/main/java/practice/jpa1/domain/Book.java
+++ b/src/main/java/practice/jpa1/domain/Book.java
@@ -1,0 +1,12 @@
+package practice.jpa1.domain;
+
+import javax.persistence.Entity;
+
+@Entity
+public class Book extends Item {
+
+    private String author;
+
+    private String isbn;
+
+}

--- a/src/main/java/practice/jpa1/domain/Category.java
+++ b/src/main/java/practice/jpa1/domain/Category.java
@@ -13,7 +13,7 @@ import javax.persistence.ManyToOne;
 import javax.persistence.OneToMany;
 
 @Entity
-public class Category {
+public class Category extends BaseEntity {
 
     @Id
     @GeneratedValue

--- a/src/main/java/practice/jpa1/domain/Category.java
+++ b/src/main/java/practice/jpa1/domain/Category.java
@@ -1,0 +1,38 @@
+package practice.jpa1.domain;
+
+import java.util.ArrayList;
+import java.util.List;
+import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.JoinTable;
+import javax.persistence.ManyToMany;
+import javax.persistence.ManyToOne;
+import javax.persistence.OneToMany;
+
+@Entity
+public class Category {
+
+    @Id
+    @GeneratedValue
+    private Long id;
+
+    private String name;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "PARENT_ID")
+    private Category parent;
+
+    @OneToMany(mappedBy = "parent")
+    private List<Category> child = new ArrayList<>();
+
+    @ManyToMany
+    @JoinTable(name = "CATEGORY_ITEM",
+            joinColumns = @JoinColumn(name = "CATEGORY_ID"),
+            inverseJoinColumns = @JoinColumn(name = "ITEM_ID")
+    )
+    private List<Item> items = new ArrayList<>();
+
+}

--- a/src/main/java/practice/jpa1/domain/Delivery.java
+++ b/src/main/java/practice/jpa1/domain/Delivery.java
@@ -18,7 +18,7 @@ import practice.jpa1.type.DeliveryStatus;
 @Getter
 @NoArgsConstructor
 @Entity
-public class Delivery {
+public class Delivery extends BaseEntity {
 
     @Id
     @GeneratedValue

--- a/src/main/java/practice/jpa1/domain/Delivery.java
+++ b/src/main/java/practice/jpa1/domain/Delivery.java
@@ -4,6 +4,7 @@ import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.EnumType;
 import javax.persistence.Enumerated;
+import javax.persistence.FetchType;
 import javax.persistence.GeneratedValue;
 import javax.persistence.Id;
 import javax.persistence.JoinColumn;
@@ -34,7 +35,7 @@ public class Delivery extends BaseEntity {
     @Enumerated(EnumType.STRING)
     private DeliveryStatus deliveryStatus;
 
-    @OneToOne(mappedBy = "delivery")
+    @OneToOne(fetch = FetchType.LAZY, mappedBy = "delivery")
     private Order order;
 
 }

--- a/src/main/java/practice/jpa1/domain/Delivery.java
+++ b/src/main/java/practice/jpa1/domain/Delivery.java
@@ -1,0 +1,40 @@
+package practice.jpa1.domain;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.OneToOne;
+import javax.persistence.Table;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import practice.jpa1.type.DeliveryStatus;
+
+@Setter
+@Getter
+@NoArgsConstructor
+@Entity
+public class Delivery {
+
+    @Id
+    @GeneratedValue
+    @Column(name = "DELIVERY_ID")
+    private Long id;
+
+    private String city;
+
+    private String street;
+
+    private String zipcode;
+
+    @Enumerated(EnumType.STRING)
+    private DeliveryStatus deliveryStatus;
+
+    @OneToOne(mappedBy = "delivery")
+    private Order order;
+
+}

--- a/src/main/java/practice/jpa1/domain/Item.java
+++ b/src/main/java/practice/jpa1/domain/Item.java
@@ -1,0 +1,34 @@
+package practice.jpa1.domain;
+
+import java.util.ArrayList;
+import java.util.List;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.JoinTable;
+import javax.persistence.ManyToMany;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Setter
+@Getter
+@NoArgsConstructor
+@Entity
+public class Item {
+
+    @Id
+    @GeneratedValue
+    @Column(name = "ITEM_ID")
+    private Long id;
+
+    private long price;
+
+    private int stockQuantity;
+
+    @ManyToMany(mappedBy = "items")
+    private List<Category> categories = new ArrayList<>();
+
+}

--- a/src/main/java/practice/jpa1/domain/Item.java
+++ b/src/main/java/practice/jpa1/domain/Item.java
@@ -3,11 +3,12 @@ package practice.jpa1.domain;
 import java.util.ArrayList;
 import java.util.List;
 import javax.persistence.Column;
+import javax.persistence.DiscriminatorColumn;
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.Id;
-import javax.persistence.JoinColumn;
-import javax.persistence.JoinTable;
+import javax.persistence.Inheritance;
+import javax.persistence.InheritanceType;
 import javax.persistence.ManyToMany;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -16,8 +17,10 @@ import lombok.Setter;
 @Setter
 @Getter
 @NoArgsConstructor
+@Inheritance(strategy = InheritanceType.SINGLE_TABLE)
+@DiscriminatorColumn
 @Entity
-public class Item {
+public abstract class Item extends BaseEntity {
 
     @Id
     @GeneratedValue

--- a/src/main/java/practice/jpa1/domain/Member.java
+++ b/src/main/java/practice/jpa1/domain/Member.java
@@ -17,7 +17,7 @@ import lombok.Setter;
 @NoArgsConstructor
 @Table(name = "MEMBER")
 @Entity
-public class Member {
+public class Member extends BaseEntity {
 
     @Id
     @GeneratedValue

--- a/src/main/java/practice/jpa1/domain/Member.java
+++ b/src/main/java/practice/jpa1/domain/Member.java
@@ -1,0 +1,38 @@
+package practice.jpa1.domain;
+
+import java.util.ArrayList;
+import java.util.List;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+import javax.persistence.OneToMany;
+import javax.persistence.Table;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Setter
+@Getter
+@NoArgsConstructor
+@Table(name = "MEMBER")
+@Entity
+public class Member {
+
+    @Id
+    @GeneratedValue
+    @Column(name = "MEMBER_ID")
+    private Long id;
+
+    private String name;
+
+    private String city;
+
+    private String street;
+
+    private String zipcode;
+
+    @OneToMany(mappedBy = "member")
+    private List<Order> orders = new ArrayList<>();
+
+}

--- a/src/main/java/practice/jpa1/domain/Movie.java
+++ b/src/main/java/practice/jpa1/domain/Movie.java
@@ -1,0 +1,12 @@
+package practice.jpa1.domain;
+
+import javax.persistence.Entity;
+
+@Entity
+public class Movie extends Item {
+
+    private String director;
+
+    private String actor;
+
+}

--- a/src/main/java/practice/jpa1/domain/Order.java
+++ b/src/main/java/practice/jpa1/domain/Order.java
@@ -1,0 +1,46 @@
+package practice.jpa1.domain;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
+import javax.persistence.FetchType;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+import javax.persistence.OneToMany;
+import javax.persistence.Table;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import practice.jpa1.type.OrderStatus;
+
+@Setter
+@Getter
+@NoArgsConstructor
+@Table(name = "orders")
+@Entity
+public class Order {
+
+    @Id
+    @GeneratedValue
+    @Column(name = "ORDER_ID")
+    private Long id;
+
+    @Enumerated(EnumType.STRING)
+    private OrderStatus orderStatus;
+
+    private LocalDateTime orderDate;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "MEMBER_ID")
+    private Member member;
+
+    @OneToMany(mappedBy = "order")
+    private List<OrderItem> orderItems = new ArrayList<>();
+
+}

--- a/src/main/java/practice/jpa1/domain/Order.java
+++ b/src/main/java/practice/jpa1/domain/Order.java
@@ -25,7 +25,7 @@ import practice.jpa1.type.OrderStatus;
 @NoArgsConstructor
 @Table(name = "orders")
 @Entity
-public class Order {
+public class Order extends BaseEntity {
 
     @Id
     @GeneratedValue

--- a/src/main/java/practice/jpa1/domain/Order.java
+++ b/src/main/java/practice/jpa1/domain/Order.java
@@ -3,6 +3,7 @@ package practice.jpa1.domain;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
+import javax.persistence.CascadeType;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.EnumType;
@@ -41,10 +42,10 @@ public class Order extends BaseEntity {
     @JoinColumn(name = "MEMBER_ID")
     private Member member;
 
-    @OneToMany(mappedBy = "order")
+    @OneToMany(mappedBy = "order", cascade = CascadeType.ALL)
     private List<OrderItem> orderItems = new ArrayList<>();
 
-    @OneToOne
+    @OneToOne(fetch = FetchType.LAZY, cascade = CascadeType.ALL)
     @JoinColumn(name = "DELIVERY_ID")
     private Delivery delivery;
 

--- a/src/main/java/practice/jpa1/domain/Order.java
+++ b/src/main/java/practice/jpa1/domain/Order.java
@@ -13,6 +13,7 @@ import javax.persistence.Id;
 import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
 import javax.persistence.OneToMany;
+import javax.persistence.OneToOne;
 import javax.persistence.Table;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -42,5 +43,9 @@ public class Order {
 
     @OneToMany(mappedBy = "order")
     private List<OrderItem> orderItems = new ArrayList<>();
+
+    @OneToOne
+    @JoinColumn(name = "DELIVERY_ID")
+    private Delivery delivery;
 
 }

--- a/src/main/java/practice/jpa1/domain/OrderItem.java
+++ b/src/main/java/practice/jpa1/domain/OrderItem.java
@@ -15,7 +15,7 @@ import lombok.Setter;
 @Getter
 @NoArgsConstructor
 @Entity
-public class OrderItem {
+public class OrderItem extends BaseEntity {
 
     @Id
     @GeneratedValue

--- a/src/main/java/practice/jpa1/domain/OrderItem.java
+++ b/src/main/java/practice/jpa1/domain/OrderItem.java
@@ -1,0 +1,37 @@
+package practice.jpa1.domain;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Setter
+@Getter
+@NoArgsConstructor
+@Entity
+public class OrderItem {
+
+    @Id
+    @GeneratedValue
+    @Column(name = "ORDER_ITEM_ID")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "ORDER_ID")
+    private Order order;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "ITEM_ID")
+    private Item item;
+
+    private long orderPrice;
+
+    private int count;
+
+}

--- a/src/main/java/practice/jpa1/type/DeliveryStatus.java
+++ b/src/main/java/practice/jpa1/type/DeliveryStatus.java
@@ -1,0 +1,20 @@
+package practice.jpa1.type;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum DeliveryStatus {
+
+    CREATED("생성"),
+
+    RECEIVED("접수"),
+
+    PROCESSING("처리"),
+
+    DONE("완료");
+
+    private final String description;
+
+}

--- a/src/main/java/practice/jpa1/type/OrderStatus.java
+++ b/src/main/java/practice/jpa1/type/OrderStatus.java
@@ -1,0 +1,20 @@
+package practice.jpa1.type;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum OrderStatus {
+
+    CREATED("생성"),
+
+    RECEIVED("접수"),
+
+    PROCESSING("처리"),
+
+    DONE("완료");
+
+    private final String description;
+
+}

--- a/src/main/resources/META-INF/persistence.xml
+++ b/src/main/resources/META-INF/persistence.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<persistence version="2.2"
+        xmlns="http://xmlns.jcp.org/xml/ns/persistence" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/persistence http://xmlns.jcp.org/xml/ns/persistence/persistence_2_2.xsd">
+    <persistence-unit name="hello">
+        <!-- 엔티티 -->
+        <class>practice.jpa1.domain.Member</class>
+        <class>practice.jpa1.domain.Order</class>
+        <class>practice.jpa1.domain.OrderItem</class>
+        <class>practice.jpa1.domain.Item</class>
+
+        <properties>
+            <!-- 필수 속성 -->
+            <property name="javax.persistence.jdbc.driver" value="org.h2.Driver"/>
+            <property name="javax.persistence.jdbc.user" value="sa"/>
+            <property name="javax.persistence.jdbc.password" value=""/>
+            <property name="javax.persistence.jdbc.url" value="jdbc:h2:tcp://localhost/~/test"/>
+            <property name="hibernate.dialect" value="org.hibernate.dialect.H2Dialect"/>
+
+            <!-- 옵션 -->
+            <property name="hibernate.show_sql" value="true"/>
+            <property name="hibernate.format_sql" value="true"/>
+            <property name="hibernate.use_sql_comments" value="true"/>
+            <property name="hibernate.hbm2ddl.auto" value="create" />
+        </properties>
+    </persistence-unit>
+</persistence>

--- a/src/main/resources/META-INF/persistence.xml
+++ b/src/main/resources/META-INF/persistence.xml
@@ -8,6 +8,9 @@
         <class>practice.jpa1.domain.Order</class>
         <class>practice.jpa1.domain.OrderItem</class>
         <class>practice.jpa1.domain.Item</class>
+        <class>practice.jpa1.domain.Album</class>
+        <class>practice.jpa1.domain.Book</class>
+        <class>practice.jpa1.domain.Movie</class>
         <class>practice.jpa1.domain.Delivery</class>
         <class>practice.jpa1.domain.Category</class>
 

--- a/src/main/resources/META-INF/persistence.xml
+++ b/src/main/resources/META-INF/persistence.xml
@@ -8,6 +8,8 @@
         <class>practice.jpa1.domain.Order</class>
         <class>practice.jpa1.domain.OrderItem</class>
         <class>practice.jpa1.domain.Item</class>
+        <class>practice.jpa1.domain.Delivery</class>
+        <class>practice.jpa1.domain.Category</class>
 
         <properties>
             <!-- 필수 속성 -->
@@ -21,7 +23,7 @@
             <property name="hibernate.show_sql" value="true"/>
             <property name="hibernate.format_sql" value="true"/>
             <property name="hibernate.use_sql_comments" value="true"/>
-            <property name="hibernate.hbm2ddl.auto" value="create" />
+            <property name="hibernate.hbm2ddl.auto" value="create"/>
         </properties>
     </persistence-unit>
 </persistence>


### PR DESCRIPTION
## Description
- 연관관계 매핑에 대해 학습/실습
- 다양한 연관관계를 어떻게 설정하는지 학습

## Lesson Learned
### `@~ToOne`의 기본 fetch 전략은 EAGER이므로, 항상 Lazy로 선언
- Eager Loading으로 인해 JPQL 사용 시, N+1 문제가 발생할 수 있음
- 해당 정보가 꼭 필요하다는 보장이 없으므로, 필요할 때마다 로딩하거나, 정말 전체가 필요한 경우 Fetch join등을 사용하도록 권장

### `cascade` 속성을 활용해 연관관계의 주인이 아니더라도 FK 업데이트 가능
- 추후 작성